### PR TITLE
Fix parse_model_name return type

### DIFF
--- a/backend/app/utils.py
+++ b/backend/app/utils.py
@@ -228,7 +228,7 @@ def sanitize_xml(xml_content: str) -> str:
     
     return sanitized
 
-def parse_model_name(model_name: str) -> Tuple[str, Optional[str], Optional[str]]:
+def parse_model_name(model_name: str) -> Tuple[Optional[str], str, Optional[str]]:
     """
     Parse a model name to extract provider, base name, and any suffix
     


### PR DESCRIPTION
## Summary
- correct the parse_model_name type hint

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'httpx')*

------
https://chatgpt.com/codex/tasks/task_e_683fe76aebf483259b0496a14abd1ffc